### PR TITLE
chore: release/0.3.0

### DIFF
--- a/playground/formkit.config.ts
+++ b/playground/formkit.config.ts
@@ -1,0 +1,3 @@
+import { defineFormKitConfig } from '@formkit/vue'
+
+export default defineFormKitConfig(() => ({}))

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`virtual configuration file > generates correct configuration when custom config is available 1`] = `
-"import { defaultConfig } from \\"@formkit/vue\\"
+"import { defaultConfig } from \\"@formkit/vue\\";
 import _config from \\"~/playground/formkit.config.ts\\";
 const config = typeof _config === 'function' ? _config() : _config;
 export default defaultConfig(config);"
@@ -19,7 +19,7 @@ export default config;"
 `;
 
 exports[`virtual configuration file > generates correct virtual configuration with default options 1`] = `
-"import { defaultConfig } from \\"@formkit/vue\\"
+"import { defaultConfig } from \\"@formkit/vue\\";
 const config = {};
 export default defaultConfig(config);"
 `;
@@ -45,8 +45,10 @@ import { FormKit } from '@formkit/vue'
 `;
 
 exports[`vue file transformations > injects inside root node if there is one 1`] = `
-"<script setup>import { FormKitProvider } from \\"@formkit/vue\\";
-import __formkitConfig from \\"virtual:formkit-config\\";</script>
+"<script setup>
+import { FormKitProvider } from \\"@formkit/vue\\";
+import __formkitConfig from \\"virtual:formkit-config\\";
+</script>
 <template>
     <div class=\\"fizzbuzz\\">
       
@@ -114,8 +116,10 @@ function handleLoginSubmit(values: any) {
 `;
 
 exports[`vue file transformations > injects setup block when using options api 1`] = `
-"<script setup lang=\\"ts\\">import { FormKitProvider } from \\"@formkit/vue\\";
-import __formkitConfig from \\"virtual:formkit-config\\";</script>
+"<script setup lang=\\"ts\\">
+import { FormKitProvider } from \\"@formkit/vue\\";
+import __formkitConfig from \\"virtual:formkit-config\\";
+</script>
 <script lang=\\"ts\\">
 import { FormKit } from '@formkit/vue'
 
@@ -139,8 +143,10 @@ export default {
 `;
 
 exports[`vue file transformations > injects the template block into an normally structured sfc 1`] = `
-"<script setup>import { FormKitProvider } from \\"@formkit/vue\\";
-import __formkitConfig from \\"virtual:formkit-config\\";</script>
+"<script setup>
+import { FormKitProvider } from \\"@formkit/vue\\";
+import __formkitConfig from \\"virtual:formkit-config\\";
+</script>
 <template>
   
 <FormKitProvider :config=\\"__formkitConfig\\">

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -1,40 +1,67 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`index > injects import into script setup block 1`] = `
+exports[`virtual configuration file > generates correct configuration when custom config is available 1`] = `
+"import { defaultConfig } from \\"@formkit/vue\\"
+import _config from \\"~/playground/formkit.config.ts\\";
+const config = typeof _config === 'function' ? _config() : _config;
+export default defaultConfig(config);"
+`;
+
+exports[`virtual configuration file > generates correct configuration when custom config is available and default config is disabled 1`] = `
+"import _config from \\"~/playground/formkit.config.ts\\";
+const config = typeof _config === 'function' ? _config() : _config;
+export default config;"
+`;
+
+exports[`virtual configuration file > generates correct configuration when default config is disabled 1`] = `
+"const config = {};
+export default config;"
+`;
+
+exports[`virtual configuration file > generates correct virtual configuration with default options 1`] = `
+"import { defaultConfig } from \\"@formkit/vue\\"
+const config = {};
+export default defaultConfig(config);"
+`;
+
+exports[`vue file transformations > injects import into script setup block 1`] = `
 "<script setup lang=\\"ts\\">
-import { FormKitLazyProvider } from '@formkit/vue'
+import { FormKitProvider } from \\"@formkit/vue\\";
+import __formkitConfig from \\"virtual:formkit-config\\";
 import { FormKit } from '@formkit/vue'
 </script>
 
 <template>
   
-<FormKitLazyProvider>
+<FormKitProvider :config=\\"__formkitConfig\\">
 <FormKit
     type=\\"text\\"
     label=\\"Your name\\"
     help=\\"Enter your name\\"
   />
-</FormKitLazyProvider>
+</FormKitProvider>
 
 </template>"
 `;
 
-exports[`index > injects inside root node if there is one 1`] = `
-"<script setup>import { FormKitLazyProvider } from '@formkit/vue'</script>
+exports[`vue file transformations > injects inside root node if there is one 1`] = `
+"<script setup>import { FormKitProvider } from \\"@formkit/vue\\";
+import __formkitConfig from \\"virtual:formkit-config\\";</script>
 <template>
     <div class=\\"fizzbuzz\\">
       
-<FormKitLazyProvider>
+<FormKitProvider :config=\\"__formkitConfig\\">
 <FormKit />
-</FormKitLazyProvider>
+</FormKitProvider>
 
     </div>
   </template>"
 `;
 
-exports[`index > injects inside root node with full sfc 1`] = `
+exports[`vue file transformations > injects inside root node with full sfc 1`] = `
 "<script lang=\\"ts\\" setup>
-import { FormKitLazyProvider } from '@formkit/vue'
+import { FormKitProvider } from \\"@formkit/vue\\";
+import __formkitConfig from \\"virtual:formkit-config\\";
 function handleLoginSubmit(values: any) {
   window.alert(\\"You are logged in. Credentials: 
 \\" + JSON.stringify(values));
@@ -44,21 +71,22 @@ function handleLoginSubmit(values: any) {
 <template>
   <div>
     
-<FormKitLazyProvider>
+<FormKitProvider :config=\\"__formkitConfig\\">
 <FormKit type=\\"form\\" submit-label=\\"login\\" @submit=\\"handleLoginSubmit\\">
       <FormKit type=\\"email\\" label=\\"Email\\" name=\\"email\\" />
       <FormKit type=\\"password\\" label=\\"Password\\" name=\\"password\\" />
     </FormKit>
-</FormKitLazyProvider>
+</FormKitProvider>
 
   </div>
 </template>
 "
 `;
 
-exports[`index > injects inside root node with multiple child elements 1`] = `
+exports[`vue file transformations > injects inside root node with multiple child elements 1`] = `
 "<script lang=\\"ts\\" setup>
-import { FormKitLazyProvider } from '@formkit/vue'
+import { FormKitProvider } from \\"@formkit/vue\\";
+import __formkitConfig from \\"virtual:formkit-config\\";
 function handleLoginSubmit(values: any) {
   window.alert(\\"You are logged in. Credentials: 
 \\" + JSON.stringify(values));
@@ -68,7 +96,7 @@ function handleLoginSubmit(values: any) {
 <template>
   <div>
     
-<FormKitLazyProvider>
+<FormKitProvider :config=\\"__formkitConfig\\">
 <main>
     <p>
     <FormKit type=\\"form\\" submit-label=\\"login\\" @submit=\\"handleLoginSubmit\\">
@@ -78,15 +106,16 @@ function handleLoginSubmit(values: any) {
     </p>
     </main>
     <div class=\\"filler\\">Here we go</div>
-</FormKitLazyProvider>
+</FormKitProvider>
 
   </div>
 </template>
 "
 `;
 
-exports[`index > injects setup block when using options api 1`] = `
-"<script setup lang=\\"ts\\">import { FormKitLazyProvider } from '@formkit/vue'</script>
+exports[`vue file transformations > injects setup block when using options api 1`] = `
+"<script setup lang=\\"ts\\">import { FormKitProvider } from \\"@formkit/vue\\";
+import __formkitConfig from \\"virtual:formkit-config\\";</script>
 <script lang=\\"ts\\">
 import { FormKit } from '@formkit/vue'
 
@@ -100,22 +129,23 @@ export default {
 <template>
   <div>
     
-<FormKitLazyProvider>
+<FormKitProvider :config=\\"__formkitConfig\\">
 <h1>Nothing to see here</h1>
     <FormKit type=\\"text\\" label=\\"Check me out\\" />
-</FormKitLazyProvider>
+</FormKitProvider>
 
   </div>
 </template>"
 `;
 
-exports[`index > injects the template block into an normally structured sfc 1`] = `
-"<script setup>import { FormKitLazyProvider } from '@formkit/vue'</script>
+exports[`vue file transformations > injects the template block into an normally structured sfc 1`] = `
+"<script setup>import { FormKitProvider } from \\"@formkit/vue\\";
+import __formkitConfig from \\"virtual:formkit-config\\";</script>
 <template>
   
-<FormKitLazyProvider>
+<FormKitProvider :config=\\"__formkitConfig\\">
 <FormKit />
-</FormKitLazyProvider>
+</FormKitProvider>
 
 </template>"
 `;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,8 +1,10 @@
+import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import unplugin from '../src/vite'
 import { readFileSync } from 'fs'
 
 type Transformer = {
+  load: (id: string) => Promise<string>
   transform: (code: string, id: string) => Promise<{ code: string; map?: any }>
 }
 const aboutSFCFile = readFileSync('./playground/src/pages/about.vue', 'utf-8')
@@ -10,10 +12,44 @@ const contactSFCFile = readFileSync(
   './playground/src/pages/contact.vue',
   'utf-8',
 )
-
+const rootDir = fileURLToPath(new URL('..', import.meta.url))
 const plugin: Transformer = unplugin() as Transformer
 
-describe('index', () => {
+describe('virtual configuration file', () => {
+  const loadConfig = (...args: Parameters<typeof unplugin>) =>
+    Promise.resolve(
+      args.length
+        ? (unplugin(...args) as Transformer).load('virtual:formkit-config')
+        : plugin.load('virtual:formkit-config'),
+    ).then((r) => r.replace(rootDir, '~/'))
+
+  it('generates correct virtual configuration with default options', async () => {
+    expect(await loadConfig()).toMatchSnapshot()
+  })
+
+  it('generates correct configuration when default config is disabled', async () => {
+    expect(await loadConfig({ defaultConfig: false })).toMatchSnapshot()
+  })
+
+  it('generates correct configuration when custom config is available', async () => {
+    expect(
+      await loadConfig({
+        configFile: './playground/formkit.config',
+      }),
+    ).toMatchSnapshot()
+  })
+
+  it('generates correct configuration when custom config is available and default config is disabled', async () => {
+    expect(
+      await loadConfig({
+        configFile: './playground/formkit.config',
+        defaultConfig: false,
+      }),
+    ).toMatchSnapshot()
+  })
+})
+
+describe('vue file transformations', () => {
   it('injects the template block into an normally structured sfc', async () => {
     expect(
       (


### PR DESCRIPTION
A ran some manual tests on this. Everything went swimmingly — unquestionably an improvement (thanks @danielroe).

I’m documenting those manual tests so we can eventually get something them reproduced with automated testing in this repository:

- Created a new formkit install using `npx formkit@latest -f nuxt`, specifically with `pnpm`
- Before install I used a `pnpm` override to explicitly change the installed package to this branch’s build (perhaps there is a better way, but I’ve found the symlinks using `link` can cause module resolution issues when testing things like this).
- Installed
- Checked that the default app.vue rendered properly with no hydration issues or any FOUC
- Replaced app.vue code with `<NuxtPage />` and created 2 pages `a.vue` and `b.vue` with `a.vue` having a `<FormKit>` instance and `b.vue` having none.
- Ran `nuxi analyze` to ensure we were getting the expect splits and a clean entry bundle.

Couple notes:

1. Doing this highlighted that the `@formkit/icons` package is not tree shaking properly. This is now documented (https://github.com/formkit/formkit/issues/1184).
2. The tailwindcss classes in `formkit.config.ts` should be an area of performance optimization. The only thing that needs to be there globally is the global classes. Other than that each input could be a seperate export in the generated file and directly imported. This might actually be a good candidate for `unplugin-formkit`, but I have not yet given it much further thought.